### PR TITLE
SC-9570 [API] Build a new Janus docker image with latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ############################################################
-# Dockerfile - Janus Gateway on Debian Buster
+# Dockerfile - Janus Gateway on Debian Bullseye
 # https://github.com/jemmic/docker-janus
 ############################################################
 
-# set base image debian buster with minimal packages installed
-FROM debian:buster-slim
+# set base image debian bullseye with minimal packages installed
+FROM debian:bullseye-slim
 
 # file maintainer author
 MAINTAINER Christophe Kamphaus <christophe.kamphaus@jemmic.com>
@@ -16,14 +16,14 @@ ENV CONFIG_PATH="/opt/janus/etc/janus"
 # docker build arguments
 ARG BUILD_SRC="/usr/local/src"
 
-ARG JANUS_VERSION="v1.0.0"
-ARG JANUS_LIBNICE_VERSION="0.1.18"
-ARG JANUS_PAHO_MQTT_VERSION="v1.3.10"
-ARG JANUS_RABBITMQ_VERSION="v0.11.0"
-ARG JANUS_LIBSRTP_VERSION="2.4.2"
+ARG JANUS_VERSION="v1.1.4"
+ARG JANUS_LIBNICE_VERSION="0.1.21"
+ARG JANUS_PAHO_MQTT_VERSION="v1.3.12"
+ARG JANUS_RABBITMQ_VERSION="v0.13.0"
+ARG JANUS_LIBSRTP_VERSION="2.5.0"
 ARG JANUS_USRSCTP_VERSION="0.9.5.0"
-ARG JANUS_BORINGSSL_VERSION="225e8d39b50757af56e61cd0aa7958c56c487d54"
-ARG JANUS_LIBWEBSOCKETS_VERSION="v4.3.1"
+ARG JANUS_BORINGSSL_VERSION="e9f816b12b3e68de575d21e2a9b7d76e4e5c58ac"
+ARG JANUS_LIBWEBSOCKETS_VERSION="v4.3.2"
 
 ARG JANUS_WITH_POSTPROCESSING="1"
 ARG JANUS_WITH_BORINGSSL="1"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= latest
 
 REPO = docker-janus
 NAME = janus
-INSTANCE = buster
+INSTANCE = bullseye
 
 .PHONY: build push shell run start stop rm release
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-janus
-`docker-janus` is a Debian 10 based docker image for [Meetecho's Janus Gateway](https://github.com/meetecho/janus-gateway)
+`docker-janus` is a Debian 11 based docker image for [Meetecho's Janus Gateway](https://github.com/meetecho/janus-gateway)
 
 ## Description
 

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # init build env & install apt deps
 if [ $JANUS_WITH_POSTPROCESSING = "1" ]; then export JANUS_CONFIG_OPTIONS="$JANUS_CONFIG_OPTIONS --enable-post-processing"; fi
-if [ $JANUS_WITH_BORINGSSL = "1" ]; then export JANUS_BUILD_DEPS_DEV="$JANUS_BUILD_DEPS_DEV golang-go" && export JANUS_CONFIG_OPTIONS="$JANUS_CONFIG_OPTIONS --enable-boringssl --enable-dtls-settimeout"; fi
+if [ $JANUS_WITH_BORINGSSL = "1" ]; then echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list && export JANUS_BUILD_DEPS_DEV="$JANUS_BUILD_DEPS_DEV golang-go/bullseye-backports golang-src/bullseye-backports" && export JANUS_CONFIG_OPTIONS="$JANUS_CONFIG_OPTIONS --enable-boringssl --enable-dtls-settimeout"; fi
 if [ $JANUS_WITH_DOCS = "1" ]; then export JANUS_BUILD_DEPS_DEV="$JANUS_BUILD_DEPS_DEV graphviz" && export JANUS_BUILD_DEPS_EXT="$JANUS_BUILD_DEPS_EXT flex bison file sensible-utils" && export JANUS_CONFIG_OPTIONS="$JANUS_CONFIG_OPTIONS --enable-docs"; fi
 if [ $JANUS_WITH_REST = "1" ]; then export JANUS_BUILD_DEPS_DEV="$JANUS_BUILD_DEPS_DEV libmicrohttpd-dev"; else export JANUS_CONFIG_OPTIONS="$JANUS_CONFIG_OPTIONS --disable-rest"; fi
 if [ $JANUS_WITH_DATACHANNELS = "0" ]; then export JANUS_CONFIG_OPTIONS="$JANUS_CONFIG_OPTIONS --disable-data-channels"; fi
@@ -41,9 +41,10 @@ make install
 
 # build boringssl
 if [ $JANUS_WITH_BORINGSSL = "1" ]; then
+
     git clone https://boringssl.googlesource.com/boringssl ${BUILD_SRC}/boringssl
     cd ${BUILD_SRC}/boringssl
-    git checkout ${JANUS_BORINGSSL_VERSION}
+#    git checkout ${JANUS_BORINGSSL_VERSION}
     sed -i s/" -Werror"//g CMakeLists.txt
     mkdir -p ${BUILD_SRC}/boringssl/build
     cd ${BUILD_SRC}/boringssl/build

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ if [ $JANUS_WITH_BORINGSSL = "1" ]; then
 
     git clone https://boringssl.googlesource.com/boringssl ${BUILD_SRC}/boringssl
     cd ${BUILD_SRC}/boringssl
-#    git checkout ${JANUS_BORINGSSL_VERSION}
+    git checkout ${JANUS_BORINGSSL_VERSION}
     sed -i s/" -Werror"//g CMakeLists.txt
     mkdir -p ${BUILD_SRC}/boringssl/build
     cd ${BUILD_SRC}/boringssl/build


### PR DESCRIPTION
This PR aims to upgrade the Janus server version along with its library dependencies. Also upgraded the base debian image from buster to bullseye.